### PR TITLE
Fix deploy error when running lib-deploy

### DIFF
--- a/.github/workflows/lib-deploy.yml
+++ b/.github/workflows/lib-deploy.yml
@@ -22,26 +22,23 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+        run:
+          pip install twine --user
+          pip install build --user
 
-      - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
-          pip install twine
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Publish package to Github Packages
         env:
           TWINE_USERNAME: ${{ github.actor }}
           TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: |
+        run:
           twine upload --repository-url https://upload.pkg.github.com/Face-Tagger/facetagger-lib dist/*
 
       - name: Create Github release draft


### PR DESCRIPTION
## Description
This PR merges the `fix/fix-deploy-error` branch into `develop`.

<br>

## Fix
- Change build method to gh-action-pypi-publish and fix deploy error

<br>

Please check the build workflows pass before merging.