### PR TITLE
Fix duplicate github action trigger

### DIFF
--- a/.github/workflows/lib-test.yml
+++ b/.github/workflows/lib-test.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build_and_test:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
This PR merges the `fix/fix-duplicate-github-action-trigger` branch into `develop`.

<br>

## Fix
- Resolved duplicate GitHub Action triggers on push and pull-request events.
- 
<br>

Please check the build workflows pass before merging.